### PR TITLE
PoC: prompt for missing arguments & enum support

### DIFF
--- a/app/Console/CommandWithEnumArgs.php
+++ b/app/Console/CommandWithEnumArgs.php
@@ -1,19 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Console;
 
-use Tempest\Console\Console;
-use Tempest\Console\ConsoleCommand;
-use Tempest\Console\ConsoleArgument;
 use App\Enums\AuthenticationStrategy;
+use Tempest\Console\Console;
+use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
 
 final readonly class CommandWithEnumArgs
 {
-
     public function __construct(
         protected Console $console,
-    )
-    {
+    ) {
 
     }
 
@@ -34,10 +34,8 @@ final readonly class CommandWithEnumArgs
             aliases: ['token'],
         )]
         string $bearerToken,
-    )
-    {
+    ) {
         $this->console->writeln("First enum argument: {$strategy->value}");
         $this->console->writeln("Bearer token: {$bearerToken}");
     }
-
 }

--- a/app/Console/CommandWithEnumArgs.php
+++ b/app/Console/CommandWithEnumArgs.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console;
+
+use Tempest\Console\Console;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleArgument;
+use App\Enums\AuthenticationStrategy;
+
+final readonly class CommandWithEnumArgs
+{
+
+    public function __construct(
+        protected Console $console,
+    )
+    {
+
+    }
+
+    #[ConsoleCommand(
+        name: 'enums:command',
+        description: 'Command with enum arguments',
+        help: 'Help text for command with enum arguments'
+    )]
+    public function command(
+        #[ConsoleArgument(
+            description: 'The first enum argument',
+            help: 'Extended help text for the first enum argument',
+            aliases: ['auth'],
+        )]
+        AuthenticationStrategy $strategy,
+        #[ConsoleArgument(
+            description: 'The bearer token for authentication',
+            aliases: ['token'],
+        )]
+        string $bearerToken,
+    )
+    {
+        $this->console->writeln("First enum argument: {$strategy->value}");
+        $this->console->writeln("Bearer token: {$bearerToken}");
+    }
+
+}

--- a/app/Console/CommandWithEnumArgs.php
+++ b/app/Console/CommandWithEnumArgs.php
@@ -24,8 +24,7 @@ final readonly class CommandWithEnumArgs
     )]
     public function command(
         #[ConsoleArgument(
-            description: 'The first enum argument',
-            help: 'Extended help text for the first enum argument',
+            description: 'The authentication strategy',
             aliases: ['auth'],
         )]
         AuthenticationStrategy $strategy,

--- a/app/Console/Package.php
+++ b/app/Console/Package.php
@@ -9,7 +9,6 @@ use Tempest\Console\ConsoleCommand;
 
 final readonly class Package
 {
-
     #[ConsoleCommand]
     public function list(): void
     {

--- a/app/Console/Package.php
+++ b/app/Console/Package.php
@@ -9,6 +9,7 @@ use Tempest\Console\ConsoleCommand;
 
 final readonly class Package
 {
+
     #[ConsoleCommand]
     public function list(): void
     {
@@ -22,7 +23,7 @@ final readonly class Package
             with a new line',
             aliases: ['n'],
         )]
-        string $name
+        string $name,
     ): void {
     }
 }

--- a/app/Enums/AuthenticationStrategy.php
+++ b/app/Enums/AuthenticationStrategy.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum AuthenticationStrategy: string
+{
+    case OAUTH = 'oauth';
+    case JWT = 'jwt';
+}

--- a/src/ConsoleArgumentDefinition.php
+++ b/src/ConsoleArgumentDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Console;
 
+use BackedEnum;
 use ReflectionNamedType;
 use ReflectionParameter;
 
@@ -18,6 +19,7 @@ final readonly class ConsoleArgumentDefinition
         public ?string $description = null,
         public array $aliases = [],
         public ?string $help = null,
+        public array $choices = [],
     ) {
     }
 
@@ -36,6 +38,10 @@ final readonly class ConsoleArgumentDefinition
             $typeName = '';
         }
 
+        if (enum_exists($typeName) && is_subclass_of($typeName, BackedEnum::class)) {
+            $choices = array_map(fn (BackedEnum $case) => $case->value, $typeName::cases());
+        }
+
         return new ConsoleArgumentDefinition(
             name: $parameter->getName(),
             type: $typeName,
@@ -45,6 +51,7 @@ final readonly class ConsoleArgumentDefinition
             description: $attribute?->description,
             aliases: $attribute->aliases ?? [],
             help: $attribute?->help,
+            choices: $choices ?? [],
         );
     }
 

--- a/src/ConsoleInputBuilder.php
+++ b/src/ConsoleInputBuilder.php
@@ -39,7 +39,8 @@ final class ConsoleInputBuilder
         if (count($invalidDefinitions)) {
             throw new InvalidCommandException(
                 $this->command,
-                $invalidDefinitions
+                $invalidDefinitions,
+                $this->argumentBag,
             );
         }
 

--- a/src/Exceptions/InvalidCommandException.php
+++ b/src/Exceptions/InvalidCommandException.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Exceptions;
 
-use BackedEnum;
-use Tempest\Validation\Rules\Enum;
-use Tempest\Validation\Rules\Length;
-use Tempest\Console\ConsoleArgumentBag;
-use Tempest\Console\ConsoleInputArgument;
+use Exception;
 use Tempest\Console\Actions\RenderConsoleCommand;
 use Tempest\Console\Console;
+use Tempest\Console\ConsoleArgumentBag;
 use Tempest\Console\ConsoleArgumentDefinition;
 use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleInputArgument;
+use Tempest\Validation\Rules\Length;
 
 final class InvalidCommandException extends ConsoleException
 {
@@ -50,7 +49,7 @@ final class InvalidCommandException extends ConsoleException
 
     /**
      * @return array
-     * @throws \Exception
+     * @throws Exception
      */
     private function promptForMissingArguments(Console $console): array
     {

--- a/src/Exceptions/InvalidCommandException.php
+++ b/src/Exceptions/InvalidCommandException.php
@@ -48,8 +48,9 @@ final class InvalidCommandException extends ConsoleException
     }
 
     /**
+     * @param Console $console
+     *
      * @return array
-     * @throws Exception
      */
     private function promptForMissingArguments(Console $console): array
     {

--- a/tests/Exceptions/InvalidCommandExceptionTest.php
+++ b/tests/Exceptions/InvalidCommandExceptionTest.php
@@ -35,4 +35,11 @@ class InvalidCommandExceptionTest extends TestCase
             ->assertDoesNotContain('Invalid command usage')
             ->assertDoesNotContain('Missing');
     }
+
+    public function test_it_will_prompt_for_missing_arguments()
+    {
+        $this->console
+            ->call('enums:command')
+            ->assertContains('Missing arguments: auth, token');
+    }
 }


### PR DESCRIPTION
Adds a rescue for commands that got executed without arguments provided

![image](https://github.com/tempestphp/tempest-console/assets/43403182/e46fbb1e-e5ad-466e-9feb-fa0e773b711b)
![image](https://github.com/tempestphp/tempest-console/assets/43403182/166bb382-1643-46cd-aba5-e9574b9e805b)

Note: it's targeted towards io-refactor, but should really be target towards main after io-refactor gets merged