### PR TITLE
Sub-minute scheduler

### DIFF
--- a/src/Scheduler/Every.php
+++ b/src/Scheduler/Every.php
@@ -7,6 +7,8 @@ namespace Tempest\Console\Scheduler;
 enum Every
 {
     case SECOND;
+    case QUARTER_MINUTE;
+    case HALF_MINUTE;
     case MINUTE;
     case QUARTER;
     case HALF_HOUR;
@@ -21,6 +23,8 @@ enum Every
     {
         return match ($this) {
             self::SECOND => new Interval(seconds: 1),
+            self::QUARTER_MINUTE => new Interval(seconds: 15),
+            self::HALF_MINUTE => new Interval(seconds: 30),
             self::MINUTE => new Interval(minutes: 1),
             self::QUARTER => new Interval(minutes: 15),
             self::HALF_HOUR => new Interval(minutes: 30),

--- a/src/Scheduler/GenericScheduler.php
+++ b/src/Scheduler/GenericScheduler.php
@@ -10,7 +10,7 @@ use Tempest\Console\Commands\SchedulerRunInvocationCommand;
 final class GenericScheduler implements Scheduler
 {
     public const string CACHE_PATH = __DIR__ . '/last-schedule-run.cache.php';
-    public const string INTERRUPT_PATH = __DIR__ . '/last-interrupt.cache.php';
+    public const string INTERRUPT_PATH = __DIR__ . '/schedule.lock.cache.php';
 
     private DateTime $end;
     private DateTime $start;

--- a/src/Scheduler/GenericScheduler.php
+++ b/src/Scheduler/GenericScheduler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tempest\Console\Scheduler;
 
 use DateTime;
-use Tempest\Console\ConsoleOutput;
 use Tempest\Console\Commands\SchedulerRunInvocationCommand;
 
 final class GenericScheduler implements Scheduler

--- a/src/Scheduler/GenericScheduler.php
+++ b/src/Scheduler/GenericScheduler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Console\Scheduler;
 
 use DateTime;
+use Tempest\Console\ConsoleOutput;
 use Tempest\Console\Commands\SchedulerRunInvocationCommand;
 
 final class GenericScheduler implements Scheduler
@@ -51,12 +52,8 @@ final class GenericScheduler implements Scheduler
                 $this->execute($command);
             }
 
-            // Calculate how much we should wait to preserve start-of-second accuracy
-            $sleepTime = ((int) $nextSecondStart->format('u') - (int) $currentReferenceTime->format('u')) ?: 1;
-
-            if ($sleepTime > 0) {
-                usleep($sleepTime * 1_000_000);
-            }
+            // todo: once we have a date lib supporting microseconds, we should subtract delta time from this, so it always run at the start of the second
+            usleep(1_000_000);
 
             $currentReferenceTime = $nextSecondStart;
         }

--- a/tests/Scheduler/EveryTest.php
+++ b/tests/Scheduler/EveryTest.php
@@ -22,6 +22,24 @@ final class EveryTest extends TestCase
         $this->assertSame(1, $interval->inSeconds());
     }
 
+    public function test_every_quarter_minute_gets_transformed_to_interval()
+    {
+        $every = Every::QUARTER_MINUTE;
+        $interval = $every->toInterval();
+
+        $this->assertSame(15, $interval->seconds);
+        $this->assertSame(15, $interval->inSeconds());
+    }
+
+    public function test_every_half_minute_gets_transformed_to_interval()
+    {
+        $every = Every::HALF_MINUTE;
+        $interval = $every->toInterval();
+
+        $this->assertSame(30, $interval->seconds);
+        $this->assertSame(30, $interval->inSeconds());
+    }
+
     public function test_every_minute_gets_transformed_to_interval()
     {
         $every = Every::MINUTE;

--- a/tests/Scheduler/GenericSchedulerTest.php
+++ b/tests/Scheduler/GenericSchedulerTest.php
@@ -20,6 +20,8 @@ use Tests\Tempest\Console\TestCase;
  */
 final class GenericSchedulerTest extends TestCase
 {
+    private int $pid = 1;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -32,44 +34,7 @@ final class GenericSchedulerTest extends TestCase
 
     public function test_scheduler_executes_handlers()
     {
-        $executor = $this->createMock(NullInvocationExecutor::class);
-
-        $executor->expects($this->once())
-            ->method('execute')
-            ->with($this->equalTo('(php tempest scheduler:invoke Tests\\\Tempest\\\Console\\\Scheduler\\\GenericSchedulerTest::handler) >> /dev/null &'));
-
-        $config = new SchedulerConfig();
-        $config->addHandlerInvocation(
-            new ReflectionMethod($this, 'handler'),
-            new Schedule(Every::SECOND)
-        );
-
-        $scheduler = new GenericScheduler($config, $executor);
-        $scheduler->run();
-    }
-
-    public function test_scheduler_executes_commands()
-    {
-        $executor = $this->createMock(NullInvocationExecutor::class);
-
-        $executor->expects($this->once())
-            ->method('execute')
-            ->with($this->equalTo('(php tempest command) >> /dev/null &'));
-
-        $config = new SchedulerConfig();
-        $config->addCommandInvocation(
-            new ReflectionMethod($this, 'command'),
-            new ConsoleCommand('command'),
-            new Schedule(Every::SECOND)
-        );
-
-        $scheduler = new GenericScheduler($config, $executor);
-        $scheduler->run();
-    }
-
-    public function test_scheduler_only_dispatches_the_command_in_desired_times()
-    {
-        $at = new DateTime('2024-05-01 00:00:00');
+        $at = new DateTime('2024-05-01 00:00:59');
 
         $executor = $this->createMock(NullInvocationExecutor::class);
 
@@ -83,14 +48,37 @@ final class GenericSchedulerTest extends TestCase
             new Schedule(Every::MINUTE)
         );
 
-        $scheduler = new GenericScheduler($config, $executor);
+        $scheduler = new GenericScheduler($config, $executor, $this->pid);
         $scheduler->run($at);
+    }
 
-        // command won't run twice in a row
+    public function test_scheduler_executes_commands()
+    {
+        $at = new DateTime("2024-05-01 00:00:59");
+
+        $executor = $this->createMock(NullInvocationExecutor::class);
+
+        $executor->expects($this->once())
+            ->method('execute')
+            ->with($this->equalTo('(php tempest command) >> /dev/null &'));
+
+        $config = new SchedulerConfig();
+        $config->addCommandInvocation(
+            new ReflectionMethod($this, 'command'),
+            new ConsoleCommand('command'),
+            new Schedule(Every::MINUTE)
+        );
+
+        $scheduler = new GenericScheduler($config, $executor, $this->pid);
         $scheduler->run($at);
+    }
 
-        // nor when it's called before the next minute
-        $scheduler->run($at->modify('+30 seconds'));
+    /**
+     * @slow
+     */
+    public function test_scheduler_only_dispatches_the_command_in_desired_times()
+    {
+        $at = new DateTime('2024-05-01 00:00:59');
 
         $executor = $this->createMock(NullInvocationExecutor::class);
 
@@ -98,9 +86,52 @@ final class GenericSchedulerTest extends TestCase
             ->method('execute')
             ->with($this->equalTo('(php tempest scheduler:invoke Tests\\\Tempest\\\Console\\\Scheduler\\\GenericSchedulerTest::handler) >> /dev/null &'));
 
-        $scheduler = new GenericScheduler($config, $executor);
+        $config = new SchedulerConfig();
+        $config->addHandlerInvocation(
+            new ReflectionMethod($this, 'handler'),
+            new Schedule(Every::MINUTE)
+        );
 
-        $scheduler->run($at->modify('+1 minute'));
+        $scheduler = new GenericScheduler($config, $executor, $this->pid);
+        $scheduler->run($at);
+
+        // command won't run twice in a row
+        $scheduler->run($at);
+
+        $newAt = $at->modify('+60 seconds');
+
+        $executor = $this->createMock(NullInvocationExecutor::class);
+
+        $executor->expects($this->once())
+            ->method('execute')
+            ->with($this->equalTo('(php tempest scheduler:invoke Tests\\\Tempest\\\Console\\\Scheduler\\\GenericSchedulerTest::handler) >> /dev/null &'));
+
+        $scheduler = new GenericScheduler($config, $executor, $this->pid + 1);
+        $scheduler->run($newAt);
+    }
+
+    /**
+     * @slow
+     */
+    public function test_sub_minute_scheduler_will_only_run_to_the_next_minute_with_a_long_sleep()
+    {
+        $at = new DateTime('2024-05-01 00:00:57');
+
+        $executor = $this->createMock(NullInvocationExecutor::class);
+
+        $executor->expects($this->exactly(3))
+            ->method('execute')
+            ->with($this->equalTo('(php tempest scheduler:invoke Tests\\\Tempest\\\Console\\\Scheduler\\\GenericSchedulerTest::handler) >> /dev/null &'));
+
+        $config = new SchedulerConfig();
+        $config->addHandlerInvocation(
+            new ReflectionMethod($this, 'handler'),
+            new Schedule(Every::SECOND)
+        );
+
+        $scheduler = new GenericScheduler($config, $executor, $this->pid);
+
+        $scheduler->run($at);
     }
 
     // dummy handler for testing


### PR DESCRIPTION
This PR, when merged, adds support for sub-minute schedule runs

It also prevents two schedulers from running at the same time, when new scheduler runs, we are going to break the execution.

I am not super happy with the tests, but I don't really know how to improve them (i.e we lack tests against two schedulers not running at the same time) so if you have any ideas how to implement it, lemme know - would appreciate help here.